### PR TITLE
PR: README badges and install ladder, docs.yml dependency fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,17 @@ jobs:
           python-version: "3.11"
 
       - name: Install docs dependencies
-        run: pip install -e ".[docs]"
+        # mkdocstrings (docs/kernels/index.md's `::: rl_triton...` blocks)
+        # imports rl_triton to read docstrings/signatures, so torch and
+        # triton must be importable -- but never executed, so the CPU-only
+        # torch wheel is enough and avoids the multi-GB CUDA download a
+        # plain `pip install -e ".[docs]"` would otherwise trigger.
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install triton
+          pip install -e ".[docs]" --no-deps
+          pip install mkdocs>=1.6 mkdocs-material>=9.7 \
+            mkdocs-include-markdown-plugin>=7.3 "mkdocstrings[python]>=1.0"
 
       - name: Configure git for gh-deploy
         run: |

--- a/README.md
+++ b/README.md
@@ -33,11 +33,43 @@ benchmark methodology is available:
 
 ## Installation
 
+### Requirements
+
+- Linux with a CUDA-capable GPU (Triton compiles and runs GPU kernels; there is no
+  CPU fallback).
+- Python >=3.10 (tested on 3.10, 3.11).
+- PyTorch >=2.2, Triton >=2.3 (installed automatically as dependencies).
+
+### Install
+
+**Use it in your project:**
+
+```bash
+pip install git+https://github.com/simonsays1980/rl-triton
+```
+
+**From source, editable (for modifying the kernels):**
+
 <!-- INSTALL_START -->
+```bash
+git clone https://github.com/simonsays1980/rl-triton
+cd rl-triton
+pip install -e .
+```
+
+**Contributors (adds test/dev tooling):**
+
 ```bash
 pip install -e ".[dev]"
 ```
 <!-- INSTALL_END -->
+
+The package installs as `rl-triton` but imports as `rl_triton` (Python identifiers
+can't contain hyphens):
+
+```python
+from rl_triton import compute_gae
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 High-performance [Triton](https://github.com/openai/triton) GPU kernels for common reinforcement learning computations.
 
+[![GPU Tests](https://github.com/simonsays1980/rl-triton/actions/workflows/gpu-tests.yml/badge.svg)](https://github.com/simonsays1980/rl-triton/actions/workflows/gpu-tests.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python >=3.10](https://img.shields.io/badge/python-%3E%3D3.10-blue.svg)](pyproject.toml)
+
 ## Kernels
 
 <!-- KERNELS_START -->


### PR DESCRIPTION
## Summary

Two commits on top of main, both docs-facing:

- Restructured READMEs install instructions into a ladder -- pip install
  from git for users, editable install from source for modifying, dev
  extra for contributors -- with a Requirements note (Linux, CUDA GPU,
  Python and dependency floors pulled from pyproject.toml) and a callout
  on the install-name vs import-name mismatch (rl-triton vs rl_triton).
- Trimmed docs.yml to install CPU-only torch and a plain triton instead of
  pulling a full CUDA build through an editable full-package install --
  mkdocstrings only needs rl_triton importable to read docstrings, never
  executed.
- Added a badge row under the README title: CI status (linked to
  gpu-tests.yml), MIT license (linked to LICENSE), and Python version
  (pulled from pyproject.tomls requires-python).

## Test plan

- [x] mkdocs build --strict passes locally
- [x] docs.yml verified end to end with the new CPU-only install --
      rl_triton imports successfully, mkdocstrings renders docstrings,
      full build succeeds
- [ ] CI badge will show unknown until the repo is public
