### PR TITLE
docs: make --version example a placeholder, not a stale tag

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ Use `--no-update` to print results without staging anything. A staged candidate 
 the published `benchmarks.md` only when explicitly promoted with a version tag:
 
 ```bash
-python tests/bench_release.py --promote --version v0.1.2
+python tests/bench_release.py --promote --version <new-release-tag>   # e.g. v0.1.4
 ```
 
 ## Performance


### PR DESCRIPTION
The docs site's promote-command example hardcoded --version v0.1.2,
which was already stale by v0.1.3 and would go stale again every
release. Swapped for an explicit placeholder so it can't silently
outdate.