### PR TITLE
docs: add Zenodo DOI to CITATION.cff and README badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,21 +24,19 @@ keywords:
   - kernels
   - gae
   - vtrace
+doi: "10.5281/zenodo.21984504"
 
 # ---------------------------------------------------------------------------
 # ARXIV DOI -- ADD AFTER SUBMISSION. Nothing below exists yet; do not fill in
 # a DOI until the arXiv ID is assigned.
 #
-# 1. Add the software DOI (Zenodo, if used) as a top-level key:
-# doi: "10.5281/zenodo.XXXXXXX"
-#
-# 2. Add the arXiv identifier for the paper:
+# 1. Add the arXiv identifier for the paper:
 # identifiers:
 #   - type: other
 #     value: "arXiv:XXXX.XXXXX"
 #     description: The arXiv preprint of the accompanying paper.
 #
-# 3. Point citations at the paper rather than the software:
+# 2. Point citations at the paper rather than the software:
 # preferred-citation:
 #   type: article
 #   title: "rl-triton: High-Performance Triton GPU Kernels for Reinforcement Learning Credit Assignment"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ High-performance [Triton](https://github.com/openai/triton) GPU kernels for comm
 [![GPU Tests](https://github.com/simonsays1980/rl-triton/actions/workflows/gpu-tests.yml/badge.svg)](https://github.com/simonsays1980/rl-triton/actions/workflows/gpu-tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python >=3.10](https://img.shields.io/badge/python-%3E%3D3.10-blue.svg)](pyproject.toml)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21984504.svg)](https://doi.org/10.5281/zenodo.21984504)
 
 ## Kernels
 


### PR DESCRIPTION
Wires in the concept DOI (10.5281/zenodo.21984504) now that Zenodo has
archived the repo -- resolves to the latest release rather than pinning
to v0.1.3, matching Zenodo's own recommended practice. Adds the DOI
field to CITATION.cff and a badge to the README badge row.

arXiv identifiers/preferred-citation stay commented out in CITATION.cff;
no arXiv ID exists yet.