### PR TITLE
docs: sync getting-started install ladder with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ benchmark methodology is available:
 
 ### Install
 
+<!-- INSTALL_START -->
 **Use it in your project:**
 
 ```bash
@@ -53,7 +54,6 @@ pip install git+https://github.com/simonsays1980/rl-triton
 
 **From source, editable (for modifying the kernels):**
 
-<!-- INSTALL_START -->
 ```bash
 git clone https://github.com/simonsays1980/rl-triton
 cd rl-triton

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,15 +11,11 @@ title: Getting Started
 
 ## Installation
 
-Clone the repository and install in editable mode:
-
-```bash
-git clone https://github.com/simonsays1980/rl-triton.git
-cd rl-triton
-pip install -e ".[dev]"
-```
-
-The `[dev]` extra pulls in `pytest`, `pytest-benchmark`, and `numpy` for running tests and benchmarks.
+{%
+  include-markdown "../README.md"
+  start="<!-- INSTALL_START -->"
+  end="<!-- INSTALL_END -->"
+%}
 
 ## Quick Start
 


### PR DESCRIPTION
docs/getting-started.md hand-maintained its own Installation section
(editable clone + `[dev]` only, presented as the sole method) that had
drifted from README's actual ladder. Wired it to the same
`include-markdown` block `index.md` already uses, so it can't drift again.

That exposed a real pre-existing bug: `INSTALL_START` sat *after* the
`pip install git+...` block, so **neither** `index.md` nor
`getting-started.md` was ever including it -- the docs site's install
instructions have been missing the leading, most-common install path
since the `include-markdown` conversion. Moved the marker up to cover
the full ladder.

Verified with `mkdocs build --strict` (clean) and confirmed both pages
now render the complete ladder (`pip install git+...` -> editable clone
-> `[dev]` extras).