### PR TITLE
docs: fix README requirements floor missed in the version-pin sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ benchmark methodology is available:
 - Linux with a CUDA-capable GPU (Triton compiles and runs GPU kernels; there is no
   CPU fallback).
 - Python >=3.10 (tested on 3.10, 3.11).
-- PyTorch >=2.2, Triton >=2.3 (installed automatically as dependencies).
+- PyTorch >=2.4.1, Triton >=3.0.0 (installed automatically as dependencies).
+  Tested combination: PyTorch 2.4.1+cu124, Triton 3.0.0, CUDA 12.4 -- see
+  [Getting Started](docs/getting-started.md#requirements) for detail.
 
 ### Install
 


### PR DESCRIPTION
## Summary
- README's Requirements section still listed `PyTorch >=2.2, Triton >=2.3` — the unverified floors that `pyproject.toml`, CI, and `docs/getting-started.md` were already corrected to `torch>=2.4.1`/`triton>=3.0.0` for in #19. That sweep missed README's own hand-written copy of the same numbers.
- Updates the line to match, states the tested combination (PyTorch 2.4.1+cu124, Triton 3.0.0, CUDA 12.4), and links to `docs/getting-started.md#requirements` instead of duplicating the fuller explanation there.

## Test plan
- [x] Confirm the Requirements section now matches `pyproject.toml` and `docs/getting-started.md`