### PR TITLE
docs: wire in arXiv ID and BibTeX

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,26 +25,17 @@ keywords:
   - gae
   - vtrace
 doi: "10.5281/zenodo.21984504"
-
-# ---------------------------------------------------------------------------
-# ARXIV DOI -- ADD AFTER SUBMISSION. Nothing below exists yet; do not fill in
-# a DOI until the arXiv ID is assigned.
-#
-# 1. Add the arXiv identifier for the paper:
-# identifiers:
-#   - type: other
-#     value: "arXiv:XXXX.XXXXX"
-#     description: The arXiv preprint of the accompanying paper.
-#
-# 2. Point citations at the paper rather than the software:
-# preferred-citation:
-#   type: article
-#   title: "rl-triton: High-Performance Triton GPU Kernels for Reinforcement Learning Credit Assignment"
-#   authors:
-#     - given-names: "Lars Simon"
-#       family-names: "Zehnder"
-#       affiliation: "Independent Researcher"
-#   year: 2026
-#   journal: "arXiv preprint"
-#   doi: "10.48550/arXiv.XXXX.XXXXX"
-# ---------------------------------------------------------------------------
+identifiers:
+  - type: other
+    value: "arXiv:2608.17641"
+    description: The arXiv preprint of the accompanying paper.
+preferred-citation:
+  type: article
+  title: "rl-triton: High-Performance Triton GPU Kernels for Reinforcement Learning Credit Assignment"
+  authors:
+    - given-names: "Lars Simon"
+      family-names: "Zehnder"
+      affiliation: "Independent Researcher"
+  year: 2026
+  journal: "arXiv preprint"
+  doi: "10.48550/arXiv.2608.17641"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ High-performance [Triton](https://github.com/openai/triton) GPU kernels for rein
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python >=3.10](https://img.shields.io/badge/python-%3E%3D3.10-blue.svg)](pyproject.toml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21984504.svg)](https://doi.org/10.5281/zenodo.21984504)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.17641-b31b1b.svg)](https://arxiv.org/abs/2608.17641)
 
 ## Kernels
 
@@ -30,9 +31,19 @@ API reference): **[simonsays1980.github.io/rl-triton](https://simonsays1980.gith
 ## Paper
 
 A preprint describing the kernels, the associative-scan formulation, and the
-benchmark methodology is available:
-[paper/rl-triton.pdf](paper/rl-triton.pdf)
-(preprint -- arXiv version forthcoming).
+benchmark methodology is available on arXiv:
+[arXiv:2608.17641](https://arxiv.org/abs/2608.17641)
+([local PDF](paper/rl-triton.pdf)).
+
+```bibtex
+@article{zehnder2026rltriton,
+  title   = {rl-triton: High-Performance Triton GPU Kernels for Reinforcement Learning Credit Assignment},
+  author  = {Zehnder, Lars Simon},
+  journal = {arXiv preprint arXiv:2608.17641},
+  year    = {2026},
+  doi     = {10.48550/arXiv.2608.17641}
+}
+```
 
 ## Installation
 


### PR DESCRIPTION
Fills the placeholders left in CITATION.cff and README's Paper section
pending arXiv submission -- the paper is now live at
https://arxiv.org/abs/2608.17641.

- CITATION.cff: activates `identifiers` (arXiv ID) and `preferred-citation`
  (points citations at the paper rather than the software, per CFF
  convention once a paper DOI exists)
- README: Paper section now leads with the arXiv link, keeps the local
  PDF as a secondary link, drops "forthcoming", adds a BibTeX block
  matching preferred-citation field-for-field, and gains an arXiv badge
  in the badge row

Verified: title/year/DOI identical between CITATION.cff and README's
BibTeX, all README links resolve, `mkdocs build --strict` clean.