### PR TITLE
ci: skip GPU tests for .gitignore, CITATION.cff, LICENSE changes

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -8,8 +8,9 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "assets/**"
-      # NOT paper/rl-triton.pdf: binary, changes only alongside real releases,
-      # cheap to leave triggering CI rather than special-case a non-source file.
+      - ".gitignore"
+      - "CITATION.cff"
+      - "LICENSE"
   pull_request:
     branches: [main]          # safeguard benchmarks gate the merge
     paths-ignore: *docs-only-paths


### PR DESCRIPTION
## Summary

`paths-ignore` didn't cover `.gitignore`, `CITATION.cff`, or `LICENSE` — a PR touching only one of these still queued `correctness`/`safeguard` on a GPU runner for no reason. Adds all three to the ignore list.

`paper/rl-triton.pdf` stays deliberately excluded from the ignore list: a real content change there is release-relevant and should still gate.

Note: this PR itself edits `gpu-tests.yml`, so GitHub's workflow-file special case means GPU tests will still run once here — but not on future PRs that touch only these three files.
