### PR TITLE
docs: fix truncated Performance intro on docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See [benchmarks/README.md](benchmarks/README.md) for methodology and release pro
 
 *Full sweep, methodology, and truncation-path results: [benchmarks.md](benchmarks.md).*
 
+<!-- PERF_HEADLINE_START -->
 Representative benchmark results at `num_envs=4096, seq_len=128`. Numbers report full-call
 speedup over `torch.compile`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,6 @@ Full sweep, methodology, and truncation-path results: [Benchmarks](benchmarks.md
 
 {%
   include-markdown "../README.md"
-  start="num_envs=4096, seq_len=128"
+  start="<!-- PERF_HEADLINE_START -->"
   end="<!-- BENCH_END -->"
 %}


### PR DESCRIPTION
docs/index.md's Performance section was rendering with a truncated
intro: "`. Numbers report full-call speedup over `torch.compile`." --
missing "Representative benchmark results at `num_envs=4096, seq_len=128`".

Cause: include-markdown's `start=` matched the literal substring
`num_envs=4096, seq_len=128`, which occurs mid-sentence in README, so
the include began right after that phrase rather than at the sentence's
start. Renders fine on GitHub since README itself just reads top to
bottom -- only the docs-site mirror was affected.

Fix: added a `PERF_HEADLINE_START` HTML-comment marker before the
sentence in README, matching the marker convention every other include
in this file already uses (`KERNELS_START`, `INSTALL_START`, etc.), and
pointed docs/index.md's include at that instead of the fragile inline
text.

Verified: both pages render the full sentence and all 24 benchmark
values, `mkdocs build --strict` clean.