### PR TITLE
docs: pin git+ install to v0.1.3, fix flaky Zenodo DOI badge, prep changelog for v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to rl-triton are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/)
 
+## [Unreleased]
+
 ## [0.1.3] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ High-performance [Triton](https://github.com/openai/triton) GPU kernels for rein
 [![GPU Tests](https://github.com/simonsays1980/rl-triton/actions/workflows/gpu-tests.yml/badge.svg)](https://github.com/simonsays1980/rl-triton/actions/workflows/gpu-tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python >=3.10](https://img.shields.io/badge/python-%3E%3D3.10-blue.svg)](pyproject.toml)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21984504.svg)](https://doi.org/10.5281/zenodo.21984504)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21984504-blue.svg)](https://doi.org/10.5281/zenodo.21984504)
 [![arXiv](https://img.shields.io/badge/arXiv-2608.17641-b31b1b.svg)](https://arxiv.org/abs/2608.17641)
 
 ## Kernels
@@ -61,7 +61,7 @@ benchmark methodology is available on arXiv:
 **Use it in your project:**
 
 ```bash
-pip install git+https://github.com/simonsays1980/rl-triton
+pip install git+https://github.com/simonsays1980/rl-triton@v0.1.3
 ```
 
 **From source, editable (for modifying the kernels):**


### PR DESCRIPTION
## Summary

- Pin the README `pip install git+...` command to `@v0.1.3` so the documented install stays on the last release while v0.2 development proceeds on `main`.
- Replace the Zenodo-hosted DOI badge with a shields.io static badge for the same DOI (`10.5281/zenodo.21984504`) — the Zenodo-rendered badge frequently fails to load; same fix used by MACE.
- Add an empty `## [Unreleased]` section to `CHANGELOG.md` to start logging v0.2 changes.

## Test plan

- [ ] Confirm `README.md` renders correctly on GitHub (badge + install snippet)
- [ ] Confirm `docs/getting-started.md`'s install section (synced via snippet include) reflects the pinned command
- [ ] Verify the DOI badge loads reliably (spot-check a few reloads)
